### PR TITLE
added new identifier and action hook

### DIFF
--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -332,7 +332,7 @@ class SiteGen {
 		self::cache_sitegen_response( $identifier, $parsed_response );
 
 		// calling the action hook for the identifiers
-		do_action( NFD_SITEGEN_OPTION . '-' . strtolower( $identifier ) , $parsed_response );
+		do_action( 'newfold/ai/sitemeta-'. strtolower( $identifier ) . ':generated', $parsed_response );
 
 		try {
 			return $parsed_response;

--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -44,6 +44,10 @@ class SiteGen {
 			'site_description',
 			'content_style',
 		),
+		'siteconfig'		   => array(
+			'site_description',
+		),
+
 	);
 
 	/**
@@ -326,6 +330,9 @@ class SiteGen {
 		$parsed_response = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		self::cache_sitegen_response( $identifier, $parsed_response );
+
+		// calling the action hook for the identifiers
+		do_action( NFD_SITEGEN_OPTION . '-' . strtolower( $identifier ) , $parsed_response );
 
 		try {
 			return $parsed_response;


### PR DESCRIPTION
1. Added support for new identifier `siteconfig` 
    Eg Response : `{
    "site_title": "ZenFlow Yoga Studio",
    "tagline": "Unleash your inner peace with the power of yoga"
}`
2. Added a new action hook which is called for all identifiers
 