### PR TITLE
Adding WP CLI support to enable AI

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -33,6 +33,12 @@ if ( function_exists( 'add_action' ) ) {
 					'isHidden' => true,
 				)
 			);
+
+			// Register the custom command with WP_CLI
+			if ( defined( '\\WP_CLI' ) && \WP_CLI  ) {
+				require_once __DIR__ . '/includes/NFD_CLI.php';
+				WP_CLI::add_command( 'newfold', 'NFD_CLI' );
+			}
 		}
 	);
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -35,7 +35,7 @@ if ( function_exists( 'add_action' ) ) {
 			);
 
 			// Register the custom command with WP_CLI
-			if ( defined( '\\WP_CLI' ) && \WP_CLI  ) {
+			if ( defined( '\\WP_CLI' ) && \WP_CLI ) {
 				require_once __DIR__ . '/includes/NFD_CLI.php';
 				WP_CLI::add_command( 'newfold', 'NFD_CLI' );
 			}

--- a/includes/NFD_CLI.php
+++ b/includes/NFD_CLI.php
@@ -1,0 +1,90 @@
+<?php
+
+final class NFD_CLI {
+
+	/**
+	 * Returns the file path to save the site capabilities.
+	 *
+	 * @return string
+	 */
+	private static function capabilities_file_path() {
+		return WP_CONTENT_DIR . '/mu-plugins/site-capability-override.php';
+	}
+
+	/**
+	 * Enables and disables AI and AI Sitegen Capabilities.
+	 *
+	 * @when after_wp_load
+	 */
+	public function ai( $args ) {
+
+		switch( $args[0] ) {
+			case 'enable':
+				self::enable( $args[1] );
+				break;
+			case 'disable':
+				self::disable();
+				break;
+			default:
+				break;
+		}
+	}
+
+	/**
+	 * Enable AI and AI Sitegen capability.
+	 *
+	 * @return null
+	 */
+	private static function enable( $token ) {
+
+		if( empty( $token ) ) {
+			WP_CLI::error( "Hiive token not provided. Cannot enable AI capabilities." );
+			return;
+		}
+
+		$enable_ai_filter = '<?php 
+		add_filter(
+			"pre_transient_nfd_site_capabilities", 
+			function () { 
+				return [ 
+					"canAccessAI" 			=> true, 
+					"hasAISiteGen" 			=> true, 
+				];
+			}
+		);';
+
+		// create a php file that overrides the AI capabilities
+		if ( file_put_contents( self::capabilities_file_path(), $enable_ai_filter ) !== false ) {
+			WP_CLI::success( "AI Capabilities Enabled." );
+		} else {
+			WP_CLI::error( "Could not enable AI capabilities." );
+		}
+
+		// Update the hiive token in the option, it gets automatically encrypted while saving and decrypted while reading
+		if ( update_option( 'nfd_data_token', $token) ) {
+			WP_CLI::success( "Hiive token encrypted and saved." );
+		}
+	}
+
+	/**
+	 * Disable AI and AI Sitegen capability.
+	 *
+	 * @return null
+	 */
+	private static function disable() {
+
+		// delete the php file that overrides the AI capabilities
+		if ( unlink( self::capabilities_file_path() ) !== false ) {
+			WP_CLI::success( "AI Capabilities Disabled." );
+		} else {
+			WP_CLI::error( "Could not disable AI capabilities." );
+		}
+
+		// delete the Hiive token
+		if ( delete_option( 'nfd_data_token' ) ) {
+			WP_CLI::success( "Hiive token deleted." );
+		}
+
+	}
+}
+

--- a/includes/NFD_CLI.php
+++ b/includes/NFD_CLI.php
@@ -13,7 +13,12 @@ final class NFD_CLI {
 
 	/**
 	 * Enables and disables AI and AI Sitegen Capabilities.
-	 *
+	 * 
+	 * ## EXAMPLES
+	 * 
+	 * wp newfold ai enable <Hiive Token>
+	 * wp newfold ai disable🌞
+	 * 
 	 * @when after_wp_load
 	 */
 	public function ai( $args ) {
@@ -26,6 +31,9 @@ final class NFD_CLI {
 				self::disable();
 				break;
 			default:
+				WP_CLI::warning( "No action provided" );
+				WP_CLI::log( "Usage: wp newfold ai enable <Hiive Token>" );
+				WP_CLI::log( "       wp newfold ai disable" );
 				break;
 		}
 	}


### PR DESCRIPTION
## Proposed changes

This change adds a WP CLI sub command which can be used to enable and disable AI / AI sitegen.

Usage: 
wp newfold ai enable \<Hiive Token\>
wp newfold ai disable

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
