### PR TITLE
Fix/sitegen array string bugs

### DIFF
--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -493,7 +493,7 @@ class SiteGen {
 			if ( ! $site_classification_mapping ) {
 				$site_classification_mapping = self::generate_site_meta(
 					array(
-						'site_description' => $site_info,
+						'site_description' => $site_info['site_description'],
 					),
 					'siteclassificationmapping'
 				);

--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -438,7 +438,7 @@ class SiteGen {
 			}
 		}
 
-		$refined_description = self::get_refined_site_description( self::get_prompt_from_info( $site_info ) );
+		$refined_description = self::get_refined_site_description( $site_info['site_description'] );
 
 		$response = wp_remote_post(
 			NFD_AI_BASE . 'generateSiteMeta',


### PR DESCRIPTION
## Proposed changes

This addresses two bugs related to passing and assigning strings vs arrays when working with site description values. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->