### PR TITLE
Pass site classification in `generatePageContent` payload

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,6 +19,7 @@ if ( function_exists( 'add_action' ) ) {
 				define( 'NFD_AI_SERVICE_BASE', 'https://hiive.cloud/workers/ai-proxy/v1/' );
 				define( 'NFD_AI_BASE', 'https://hiive.cloud/workers/ai-sitegen-proxy/' );
 				define( 'NFD_PATTERNS_BASE', 'https://patterns.hiive.cloud/' );
+				define( 'NFD_CONTENT_GENERATION_BASE', 'https://patterns.hiive.cloud/api/v1/content-generation/' );
 				define( 'NFD_SITEGEN_OPTION', 'nfd-ai-site-gen' );
 			}
 

--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -552,6 +552,16 @@ class SiteGen {
 			),
 			'keywords'
 		);
+
+		// Site classification: primary and secondary types
+		$site_classification = self::get_sitegen_from_cache( 'siteclassification' );
+		$primaryType = 'other';
+		$secondaryType = 'other';
+		if ( is_array( $site_classification ) ) {
+			$primaryType = $site_classification['primaryType'] ?? 'other';
+			$secondaryType = $site_classification['slug'] ?? 'other';
+		}
+		
 		if ( ! $generated_content_structures ) {
 			$response      = wp_remote_post(
 				NFD_AI_BASE . 'generatePageContent',
@@ -570,6 +580,8 @@ class SiteGen {
 								'target_audience'  => wp_json_encode( $target_audience ),
 							),
 							'page'       => 'home',
+							'primaryType' => $primaryType,
+							'secondaryType' => $secondaryType,
 						)
 					),
 				)
@@ -811,6 +823,15 @@ class SiteGen {
 			}
 		}
 
+		// Site classification: primary and secondary types
+		$site_classification = self::get_sitegen_from_cache( 'siteclassification' );
+		$primaryType = 'other';
+		$secondaryType = 'other';
+		if ( is_array( $site_classification ) ) {
+			$primaryType = $site_classification['primaryType'] ?? 'other';
+			$secondaryType = $site_classification['slug'] ?? 'other';
+		}
+
 		$response      = wp_remote_post(
 			NFD_AI_BASE . 'generatePageContent',
 			array(
@@ -823,11 +844,13 @@ class SiteGen {
 						'hiivetoken' => HiiveConnection::get_auth_token(),
 						'prompt'     => array(
 							'site_description' => $site_description,
+							'keywords'   => wp_json_encode( $keywords ),
 							'content_style'    => wp_json_encode( $content_style ),
 							'target_audience'  => wp_json_encode( $target_audience ),
 						),
 						'page'       => $page,
-						'keywords'   => wp_json_encode( $keywords ),
+						'primaryType' => $primaryType,
+						'secondaryType' => $secondaryType,
 					)
 				),
 			)

--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -561,7 +561,7 @@ class SiteGen {
 			$primary_type   = $site_classification['primaryType'] ?? 'other';
 			$secondary_type = $site_classification['slug'] ?? 'other';
 		}
-		
+
 		if ( ! $generated_content_structures ) {
 			$response      = wp_remote_post(
 				NFD_AI_BASE . 'generatePageContent',

--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -564,15 +564,15 @@ class SiteGen {
 
 		if ( ! $generated_content_structures ) {
 			$response      = wp_remote_post(
-				NFD_AI_BASE . 'generatePageContent',
+				NFD_CONTENT_GENERATION_BASE . 'page',
 				array(
 					'headers' => array(
-						'Content-Type' => 'application/json',
+						'Content-Type'  => 'application/json',
+						'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
 					),
 					'timeout' => 60,
 					'body'    => wp_json_encode(
 						array(
-							'hiivetoken'    => HiiveConnection::get_auth_token(),
 							'prompt'        => array(
 								'site_description' => $site_description,
 								'keywords'         => wp_json_encode( $keywords ),
@@ -833,15 +833,15 @@ class SiteGen {
 		}
 
 		$response      = wp_remote_post(
-			NFD_AI_BASE . 'generatePageContent',
+			NFD_CONTENT_GENERATION_BASE . 'page',
 			array(
 				'headers' => array(
-					'Content-Type' => 'application/json',
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
 				),
 				'timeout' => 60,
 				'body'    => wp_json_encode(
 					array(
-						'hiivetoken'    => HiiveConnection::get_auth_token(),
 						'prompt'        => array(
 							'site_description' => $site_description,
 							'keywords'         => wp_json_encode( $keywords ),

--- a/includes/SiteGen/SiteGen.php
+++ b/includes/SiteGen/SiteGen.php
@@ -555,11 +555,11 @@ class SiteGen {
 
 		// Site classification: primary and secondary types
 		$site_classification = self::get_sitegen_from_cache( 'siteclassification' );
-		$primaryType = 'other';
-		$secondaryType = 'other';
+		$primary_type        = 'other';
+		$secondary_type      = 'other';
 		if ( is_array( $site_classification ) ) {
-			$primaryType = $site_classification['primaryType'] ?? 'other';
-			$secondaryType = $site_classification['slug'] ?? 'other';
+			$primary_type   = $site_classification['primaryType'] ?? 'other';
+			$secondary_type = $site_classification['slug'] ?? 'other';
 		}
 		
 		if ( ! $generated_content_structures ) {
@@ -572,16 +572,16 @@ class SiteGen {
 					'timeout' => 60,
 					'body'    => wp_json_encode(
 						array(
-							'hiivetoken' => HiiveConnection::get_auth_token(),
-							'prompt'     => array(
+							'hiivetoken'    => HiiveConnection::get_auth_token(),
+							'prompt'        => array(
 								'site_description' => $site_description,
 								'keywords'         => wp_json_encode( $keywords ),
 								'content_style'    => wp_json_encode( $content_style ),
 								'target_audience'  => wp_json_encode( $target_audience ),
 							),
-							'page'       => 'home',
-							'primaryType' => $primaryType,
-							'secondaryType' => $secondaryType,
+							'page'          => 'home',
+							'primaryType'   => $primary_type,
+							'secondaryType' => $secondary_type,
 						)
 					),
 				)
@@ -825,11 +825,11 @@ class SiteGen {
 
 		// Site classification: primary and secondary types
 		$site_classification = self::get_sitegen_from_cache( 'siteclassification' );
-		$primaryType = 'other';
-		$secondaryType = 'other';
+		$primary_type        = 'other';
+		$secondary_type      = 'other';
 		if ( is_array( $site_classification ) ) {
-			$primaryType = $site_classification['primaryType'] ?? 'other';
-			$secondaryType = $site_classification['slug'] ?? 'other';
+			$primary_type   = $site_classification['primaryType'] ?? 'other';
+			$secondary_type = $site_classification['slug'] ?? 'other';
 		}
 
 		$response      = wp_remote_post(
@@ -841,16 +841,16 @@ class SiteGen {
 				'timeout' => 60,
 				'body'    => wp_json_encode(
 					array(
-						'hiivetoken' => HiiveConnection::get_auth_token(),
-						'prompt'     => array(
+						'hiivetoken'    => HiiveConnection::get_auth_token(),
+						'prompt'        => array(
 							'site_description' => $site_description,
-							'keywords'   => wp_json_encode( $keywords ),
+							'keywords'         => wp_json_encode( $keywords ),
 							'content_style'    => wp_json_encode( $content_style ),
 							'target_audience'  => wp_json_encode( $target_audience ),
 						),
-						'page'       => $page,
-						'primaryType' => $primaryType,
-						'secondaryType' => $secondaryType,
+						'page'          => $page,
+						'primaryType'   => $primary_type,
+						'secondaryType' => $secondary_type,
 					)
 				),
 			)


### PR DESCRIPTION
## Proposed changes
When we generate site meta during onboarding, we classify the site as part of the site meta with `site_classification` identifier. However, we don't pass the classification as part of the payload when we generate the site content, instead, we reclassify the site in the Service.

We found that call can take up to 15s to resolve... So in this PR we'll be passing the previously generated site classification as part of the payload and use that in the Service.

@amartya-dev,
- Do you think the above conclusion is accurate?
- Do you see any edge case where `self::get_sitegen_from_cache( 'siteclassification' )` would be empty?

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->