### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to push translation updates.
       pull-requests: write # Required for reusable workflow to create/update pull requests.
+    timeout-minutes: 30
     with:
       text_domain: 'wp-module-ai'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,10 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required for reusable workflow to push translation updates.
       pull-requests: write # Required for reusable workflow to create/update pull requests.
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     timeout-minutes: 30
     with:
       text_domain: 'wp-module-ai'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for reusable workflow to push translation updates.
+      pull-requests: write # Required for reusable workflow to create/update pull requests.
     with:
       text_domain: 'wp-module-ai'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Branch name comes from workflow env/context only; no checkout or GitHub API calls.
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
+    timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # Branch name comes from workflow env/context only; no checkout or GitHub API calls.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,13 +6,13 @@ on:
       - main
   workflow_dispatch:
 
-# Disable permissions for all available scopes by default.
-# Any needed permissions should be configured at the job level.
-permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
@@ -32,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}
@@ -45,9 +45,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone private module/plugin repos with GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 90
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,14 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
+    permissions: {} # Workflow context only; no checkout or GitHub API calls using GITHUB_TOKEN.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -30,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for reusable workflow to publish coverage (e.g. gh-pages branch).
+      pull-requests: write # Required for reusable workflow to comment or update the PR with coverage.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -31,10 +31,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Required for reusable workflow to publish coverage (e.g. gh-pages branch).
       pull-requests: write # Required for reusable workflow to comment or update the PR with coverage.
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Workflow context only; no checkout or GitHub API calls using GITHUB_TOKEN.
+    timeout-minutes: 30
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to publish coverage (e.g. gh-pages branch).
       pull-requests: write # Required for reusable workflow to comment or update the PR with coverage.
+    timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -14,10 +14,10 @@ permissions: {}
 
 jobs:
   call-crowdin-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: write      # Required for reusable workflow to push translation commits/branches.
       pull-requests: write # Required for reusable workflow to open/update pull requests.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,13 +8,16 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: write      # Required for reusable workflow to push translation commits/branches.
+      pull-requests: write # Required for reusable workflow to open/update pull requests.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to push translation commits/branches.
       pull-requests: write # Required for reusable workflow to open/update pull requests.
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone the repo with GITHUB_TOKEN.
+    timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone the repo with GITHUB_TOKEN.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -9,9 +9,9 @@ permissions: {}
 
 jobs:
   call-crowdin-upload-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone the repo with GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # PAT via WEBHOOK_TOKEN is passed to repository-dispatch; GITHUB_TOKEN is unused.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # PAT via WEBHOOK_TOKEN is passed to repository-dispatch; GITHUB_TOKEN is unused.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/wp-module-ai/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 7 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint.yml`, `satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed) |
| Permissions commit | `416bce1` |
| Timeouts commit | `2d1cf37` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: read` [2] |
| i18n-crowdin-download.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-workflow | `contents: write`, `pull-requests: write` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow default: BEFORE top-level `permissions: contents: read` -> AFTER prescribed commented top-level `permissions: {}` -- Default grants belong at job scope per audit rules -- [3] |
| 2 | `codecoverage-main.yml` :: `get-repo-name`: BEFORE `contents: read` -> AFTER `permissions: {}` -- Job never checks out the repo or calls the GitHub API with `GITHUB_TOKEN` -- [3] |
| 3 | `codecoverage-main.yml` :: `codecoverage`: BEFORE `permissions`/`uses` ordering without inline permission comments -> AFTER `uses:` immediately followed by commented `contents: write` / `pull-requests: write` -- Matches required placement and explains why `GITHUB_TOKEN` is forwarded to the reusable workflow -- [3] |
| 4 | `brand-plugin-test-playwright.yml` :: workflow default: BEFORE top-level `permissions: contents: read` -> AFTER prescribed commented top-level `permissions: {}` -- Same rationale as other workflows -- [3] |
| 5 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- Branch name comes from workflow env/context only -- [3] |
| 6 | `brand-plugin-test-playwright.yml` :: `bluehost`, `bluehost-dev`: BEFORE `permissions` preceding `uses` and lacking inline permission comments -> AFTER `uses:` then commented `contents: read` -- Documents why `GITHUB_TOKEN` must reach the reusable workflow for cloning private repos -- [3] |
| 7 | `i18n-crowdin-download.yml` :: workflow default: BEFORE workflow-wide `contents: write` / `pull-requests: write` -> AFTER prescribed commented top-level `permissions: {}` with scopes moved onto the caller job -- Keeps workflow defaults fully restricted -- [3] |
| 8 | `auto-translate.yml`: BEFORE uncommented top-level `permissions: {}` -> AFTER prescribed two-line comment plus `permissions: {}` -- Matches mandated banner text -- [3] |
| 9 | `auto-translate.yml` :: `translate`: BEFORE `permissions` preceding `uses` with uncommented scopes -> AFTER `uses:` then commented `contents: write` / `pull-requests: write` -- Satisfies ordering guidance and explains reusable-workflow requirements -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-webhook.yml | webhook | `30` | Repository dispatch plus lightweight shell steps should finish well within half an hour. |
| lint.yml | phpcs | `30` | Composer install plus PHPCS on PHP diffs typically completes quickly but benefits from an upper bound. |
| codecoverage-main.yml | get-repo-name | `30` | Single-step metadata extraction should remain fast. |
| codecoverage-main.yml | codecoverage | `60` | Multi-version PHPUnit/Codeception coverage merges warrant more headroom than lint-only jobs. |
| brand-plugin-test-playwright.yml | setup | `30` | Branch extraction is instantaneous but still needs a ceiling like other jobs. |
| brand-plugin-test-playwright.yml | bluehost | `90` | Downstream Playwright/browser suites invoked via reusable workflows commonly exceed thirty minutes. |
| brand-plugin-test-playwright.yml | bluehost-dev | `90` | Same heavier Playwright workload as the sibling reusable-workflow job. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `30` | Crowdin upload orchestration via reusable workflow should remain bounded. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | Crowdin download + PR automation via reusable workflow benefits from the same guardrail. |
| auto-translate.yml | translate | `30` | Translation automation caller job should remain bounded even if upstream translators slow down. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Reusable workflows hosted in `newfold-labs/workflows` were not independently audited line-by-line here; verify callee behavior if those workflows begin performing additional GitHub API operations beyond checkout/publish/PR flows assumed above (especially for Crowdin jobs marked confidence `[2]`). |
| 2 | Reference review: GitHub Actions workflow syntax permissions guidance was consulted at https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions when reasoning about defaults versus explicit scopes. |


